### PR TITLE
Add `web-time` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
         run: cargo clippy --target wasm32-unknown-unknown --features web-time -- --deny warnings
 
       - name: Run Cargo clippy with details, `wasm32-unknown-unknown`-specific libs
-        run: cargo clippy --target details,wasm32-unknown-unknown --features web-time -- --deny warnings
+        run: cargo clippy --target wasm32-unknown-unknown --features details,web-time -- --deny warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo clippy --features details --no-default-features -- --deny warnings
 
       - name: Run Cargo clippy with no details, all libs
-        run: cargo clippy --features dashmap,arrayvec,simd_json,halfbrown,parking_lot,serde_json,mini_moka,hashbrown,secrecy,chrono,nonmax,time,url,extract_map_01,bitvec -- --deny warnings
+        run: cargo clippy --features dashmap,arrayvec,simd_json,halfbrown,parking_lot,serde_json,mini_moka,hashbrown,secrecy,chrono,nonmax,time,url,extract_map_01,bitvec,web-time -- --deny warnings
 
       - name: Run Cargo clippy with details, all libs
         run: cargo clippy --all-features -- --deny warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install `wasm32-unknown-unknown` target
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Run Cargo clippy with no details, no libs
         run: cargo clippy -- --deny warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,9 @@ jobs:
 
       - name: Run Cargo clippy with details, all libs
         run: cargo clippy --all-features -- --deny warnings
+
+      - name: Run Cargo clippy with no details, `wasm32-unknown-unknown`-specific libs
+        run: cargo clippy --target wasm32-unknown-unknown --features web-time -- --deny warnings
+
+      - name: Run Cargo clippy with details, `wasm32-unknown-unknown`-specific libs
+        run: cargo clippy --target details,wasm32-unknown-unknown --features web-time -- --deny warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "time",
  "typesize-derive",
  "url",
+ "web-time",
 ]
 
 [[package]]
@@ -869,6 +870,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ secrecy = { version = "0.8.0", optional = true }
 serde_json = { version = "1", optional = true }
 nonmax = { version = "0.5.5", optional = true }
 bitvec = { version = "1.0.1", optional = true }
+web-time = { version = "1.1.0", optional = true }
 typesize-derive = { version = "=0.1.7", path = "typesize-derive" }
 
 [features]
@@ -53,6 +54,7 @@ nonmax = ["dep:nonmax"]
 time = ["dep:time"]
 url = ["dep:url"]
 bitvec = ["dep:bitvec"]
+web-time = ["dep:web-time"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! - `time`: Implements [`TypeSize`] for [`time::OffsetDateTime`].
 //! - `url`: Implements [`TypeSize`] for [`url::Url`].
 //! - `bitvec`: Implements [`TypeSize`] for [`bitvec::array::BitArray`] and [`bitvec::vec::BitVec`].
+//! - `web-time`: Implements [`TypeSize`] for [`web_time::Instant`] (on platforms where this isn't a type alias to [`std::time::Instant`]).
 //!
 //! [`HashMap`]: std::collections::HashMap
 //! [`HashSet`]: std::collections::HashSet

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! - `time`: Implements [`TypeSize`] for [`time::OffsetDateTime`].
 //! - `url`: Implements [`TypeSize`] for [`url::Url`].
 //! - `bitvec`: Implements [`TypeSize`] for [`bitvec::array::BitArray`] and [`bitvec::vec::BitVec`].
-//! - `web-time`: Implements [`TypeSize`] for [`web_time::Instant`] (on platforms where this isn't a type alias to [`std::time::Instant`]).
+//! - `web-time`: Implements [`TypeSize`] for [`web_time::Instant`] and [`web_time::SystemTime`] (on platforms where these aren't type aliases to [`std::time`] types).
 //!
 //! [`HashMap`]: std::collections::HashMap
 //! [`HashSet`]: std::collections::HashSet

--- a/src/libs/mod.rs
+++ b/src/libs/mod.rs
@@ -28,3 +28,5 @@ mod simd_json;
 mod time;
 #[cfg(feature = "url")]
 mod url;
+#[cfg(feature = "web-time")]
+mod web_time;

--- a/src/libs/web_time.rs
+++ b/src/libs/web_time.rs
@@ -1,0 +1,7 @@
+#![cfg(all(target_family = "wasm", target_os = "unknown"))]
+
+use web_time::Instant;
+
+use crate::TypeSize;
+
+impl TypeSize for Instant {}

--- a/src/libs/web_time.rs
+++ b/src/libs/web_time.rs
@@ -1,7 +1,9 @@
 #![cfg(all(target_family = "wasm", target_os = "unknown"))]
 
-use web_time::Instant;
+use web_time::{Instant, SystemTime};
 
 use crate::TypeSize;
 
 impl TypeSize for Instant {}
+
+impl TypeSize for SystemTime {}


### PR DESCRIPTION
`web_time::Instant` is a re-export of `std::time::Instant` on non-`wasm32-unknown-unknown` platforms, but is its own struct on wasm unknown.

On wasm it just wraps a `std::time::Duration`, so it has no extra heap size: https://docs.rs/web-time/latest/src/web_time/time/instant.rs.html#15.

Does support for `web-time` warrant also testing CI on `wasm32-unknown-unknown`?