### PR TITLE
Move `typesize::derive::TypeSize` to `typesize::TypeSize`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,7 @@ mod vec;
 #[deprecated = "Use ptr::{Ref, RefMut}"]
 pub use ptr::{Ref, RefMut};
 
-pub mod derive {
-    pub use typesize_derive::TypeSize;
-}
+pub use typesize_derive::TypeSize;
 
 /// A trait to fetch an accurate estimate of the total memory usage of a value.
 ///

--- a/tests/details.rs
+++ b/tests/details.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "details")]
 
-use typesize::{derive::TypeSize, Field, TypeSize};
+use typesize::{Field, TypeSize};
 
 #[test]
 fn test_details() {

--- a/tests/enum_derive.rs
+++ b/tests/enum_derive.rs
@@ -1,4 +1,4 @@
-use typesize::{TypeSize, TypeSize};
+use typesize::TypeSize;
 
 #[test]
 fn enum_derive() {

--- a/tests/enum_derive.rs
+++ b/tests/enum_derive.rs
@@ -1,4 +1,4 @@
-use typesize::{derive::TypeSize, TypeSize};
+use typesize::{TypeSize, TypeSize};
 
 #[test]
 fn enum_derive() {

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -1,4 +1,4 @@
-use typesize::{derive::TypeSize, TypeSize};
+use typesize::{TypeSize, TypeSize};
 
 #[derive(Default)]
 #[allow(dead_code)]

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -1,4 +1,4 @@
-use typesize::{TypeSize, TypeSize};
+use typesize::TypeSize;
 
 #[derive(Default)]
 #[allow(dead_code)]


### PR DESCRIPTION
The `TypeSize` derive macro right now is located at a different type path to the trait itself. This seems weird to me, usually you'd (if possible) have the trait be located at the same path as the derive macro, right? This means that you don't need 2 separate imports for the trait and macro, you just need a single one. Large ecosystem crates already do this, like `serde::{Serialize, Deserialize}`. This PR moves the derive macro path to `typesize::TypeSize`.

This is a breaking change.