### PR TITLE
Add `#[typesize(with = path::to::fn)]`

### DIFF
--- a/tests/enum_derive.rs
+++ b/tests/enum_derive.rs
@@ -69,3 +69,28 @@ fn enum_generic() {
         core::mem::size_of::<Result<u8, u8>>()
     );
 }
+
+#[test]
+fn enum_with_attr() {
+    fn returns_1(_: &usize) -> usize {
+        1
+    }
+
+    fn returns_2(_: &usize) -> usize {
+        2
+    }
+
+    #[derive(TypeSize)]
+    enum Foo {
+        A(usize),
+        B(#[typesize(with = returns_1)] usize),
+        C {
+            #[typesize(with = returns_2)]
+            field: usize,
+        },
+    }
+
+    assert_eq!(Foo::A(0).extra_size(), 0);
+    assert_eq!(Foo::B(0).extra_size(), 1);
+    assert_eq!(Foo::C { field: 0 }.extra_size(), 2);
+}

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -41,6 +41,27 @@ fn struct_skip_attr() {
 }
 
 #[test]
+fn struct_with_attr() {
+    const EXTRA_SIZE: usize = 42;
+
+    fn my_extra_size(field: &usize) -> usize {
+        EXTRA_SIZE
+    }
+
+    #[derive(Default, TypeSize)]
+    struct NamedWith {
+        #[typesize(with = my_extra_size)]
+        field: usize,
+    }
+
+    #[derive(Default, TypeSize)]
+    struct UnnamedWith(#[typesize(with = my_extra_size)] usize);
+
+    assert_eq!(NamedWith::default().get_size(), EXTRA_SIZE);
+    assert_eq!(UnnamedWith::default().get_size(), EXTRA_SIZE);
+}
+
+#[test]
 fn struct_unit() {
     #[derive(TypeSize)]
     struct Unit;

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -44,7 +44,7 @@ fn struct_skip_attr() {
 fn struct_with_attr() {
     const EXTRA_SIZE: usize = 42;
 
-    fn my_extra_size(field: &usize) -> usize {
+    fn my_extra_size(_field: &usize) -> usize {
         EXTRA_SIZE
     }
 
@@ -57,8 +57,8 @@ fn struct_with_attr() {
     #[derive(Default, TypeSize)]
     struct UnnamedWith(#[typesize(with = my_extra_size)] usize);
 
-    assert_eq!(NamedWith::default().get_size(), EXTRA_SIZE);
-    assert_eq!(UnnamedWith::default().get_size(), EXTRA_SIZE);
+    assert_eq!(NamedWith::default().extra_size(), EXTRA_SIZE);
+    assert_eq!(UnnamedWith::default().extra_size(), EXTRA_SIZE);
 }
 
 #[test]

--- a/typesize-derive/src/lib.rs
+++ b/typesize-derive/src/lib.rs
@@ -249,6 +249,9 @@ struct GenerationRet {
 ///
 /// Use `#[typesize(skip)]` on a field to assume it does not manage any external memory.
 ///
+/// Use `#[typesize(with = path::to::fn)]` on a field to specify a custom `extra_size` for that field.
+/// The function accepts a reference to the type of the field.
+///
 /// This will avoid requiring `TypeSize` to be implemented for this field, however may lead to undercounted results if the assumption does not hold.
 ///
 /// # Struct Mode

--- a/typesize-derive/src/lib.rs
+++ b/typesize-derive/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, Punct, Spacing, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, DeriveInput, Field, Token};
+use syn::{parse_macro_input, DeriveInput, Field};
 
 mod r#enum;
 mod r#struct;

--- a/typesize-derive/src/struct.rs
+++ b/typesize-derive/src/struct.rs
@@ -12,32 +12,44 @@ fn field_details_visit_fields<'a>(
     transform_named: impl Fn(&'a Ident) -> TokenStream + 'a,
     transform_unnamed: impl Fn(usize) -> TokenStream + 'a,
     arg_pass_mode: PassMode,
-) -> TokenStream {
-    use crate::{for_each_field, gen_call_with_arg};
+) -> syn::Result<TokenStream> {
+    use crate::{for_each_field, gen_call_with_arg, FieldConfig};
 
     let exprs = for_each_field(
         fields,
         Punct::new(',', Spacing::Alone),
         transform_named,
         transform_unnamed,
-        move |ident, name, skip_field| {
+        move |ident, name, config| {
             let (size_expr, collection_items_expr);
-            if skip_field.0 {
-                size_expr = quote!(0);
-                collection_items_expr = quote!(None);
-            } else {
-                size_expr = gen_call_with_arg(
-                    &quote!(::typesize::TypeSize::get_size),
-                    &ident,
-                    arg_pass_mode,
-                );
+            match config {
+                FieldConfig::Skip => {
+                    size_expr = quote!(0);
+                    collection_items_expr = quote!(None);
+                }
+                FieldConfig::With(_) => {
+                    size_expr = gen_call_with_arg(
+                        &quote!(::typesize::TypeSize::get_size),
+                        &ident,
+                        arg_pass_mode,
+                    );
 
-                collection_items_expr = gen_call_with_arg(
-                    &quote!(::typesize::TypeSize::get_collection_item_count),
-                    &ident,
-                    arg_pass_mode,
-                );
-            };
+                    collection_items_expr = quote!(None);
+                }
+                FieldConfig::Default => {
+                    size_expr = gen_call_with_arg(
+                        &quote!(::typesize::TypeSize::get_size),
+                        &ident,
+                        arg_pass_mode,
+                    );
+
+                    collection_items_expr = gen_call_with_arg(
+                        &quote!(::typesize::TypeSize::get_collection_item_count),
+                        &ident,
+                        arg_pass_mode,
+                    );
+                }
+            }
 
             quote!(
                 ::typesize::Field {
@@ -48,12 +60,12 @@ fn field_details_visit_fields<'a>(
             )
         },
     )
-    .unwrap_or_default();
+    .unwrap_or_else(|| Ok(TokenStream::default()))?;
 
-    quote!(vec![#exprs])
+    Ok(quote!(vec![#exprs]))
 }
 
-pub(crate) fn gen_struct(fields: &syn::Fields, is_packed: bool) -> GenerationRet {
+pub(crate) fn gen_struct(fields: &syn::Fields, is_packed: bool) -> syn::Result<GenerationRet> {
     let transform_named = |ident| quote!(self.#ident);
     let transform_unnamed = |index| {
         let ident = syn::Index::from(index);
@@ -66,19 +78,19 @@ pub(crate) fn gen_struct(fields: &syn::Fields, is_packed: bool) -> GenerationRet
         PassMode::InsertRef
     };
 
-    GenerationRet {
+    Ok(GenerationRet {
         extra_size: extra_details_visit_fields(
             fields,
             transform_named,
             transform_unnamed,
             pass_mode,
-        ),
+        )?,
         #[cfg(feature = "details")]
         details: Some(field_details_visit_fields(
             fields,
             transform_named,
             transform_unnamed,
             pass_mode,
-        )),
-    }
+        )?),
+    })
 }


### PR DESCRIPTION
Fixes #4.

Adds `#[typesize(with = path::to::fn)]` attribute to the derive macro which lets you specify a custom `extra_size` function for the field which the attribute is applied on.

This reworks a bunch of the macro code to pass a `syn::Result` up the call stack, since parsing the attribute can now fail. Also adds docs and tests.

Side note: with all of the recent PRs, does this justify a new release? I'd like to use all of these new features in my own crate without having to deal with annoying wrapper types just to implement `TypeSize` on them.