### PR TITLE
Fix no-std, and targets with no 64-bit atomics

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"mcr.microsoft.com/devcontainers/rust:latest"}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,1 +1,0 @@
-{"image":"mcr.microsoft.com/devcontainers/rust:latest"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install generic target with no std
+        run: rustup target add x86_64-unknown-none
+
+      - name: Install generic target with no std, no CAS atomics
+        run: rustup target add thumbv6m-arm-eabi
+
       - name: Install `wasm32-unknown-unknown` target
         run: rustup target add wasm32-unknown-unknown
 
@@ -46,8 +52,17 @@ jobs:
       - name: Run Cargo clippy with details, no libs
         run: cargo clippy --features details -- --deny warnings
 
-      - name: Run Cargo clippy with details, no std, no libs
-        run: cargo clippy --features details --no-default-features -- --deny warnings
+      - name: Run Cargo clippy with no std, no details, no libs
+        run: cargo clippy --target x86_64-unknown-none --no-default-features -- --deny warnings
+
+      - name: Run Cargo clippy with no std, details, no libs
+        run: cargo clippy --target x86_64-unknown-none --no-default-features --features details -- --deny warnings
+
+      - name: Run Cargo clippy with no std, no details, no-std-compatible libs
+        run: cargo clippy --target x86_64-unknown-none --no-default-features --features arrayvec,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,url,bitvec -- --deny warnings
+
+      - name: Run Cargo clippy with no std, details, no-std-compatible libs
+        run: cargo clippy --target x86_64-unknown-none --no-default-features --features details,arrayvec,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,url,bitvec -- --deny warnings
 
       - name: Run Cargo clippy with no details, all libs
         run: cargo clippy --features dashmap,arrayvec,simd_json,halfbrown,parking_lot,serde_json,mini_moka,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,url,extract_map_01,bitvec,web-time -- --deny warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,13 @@ jobs:
       - name: Install generic target with no std
         run: rustup target add x86_64-unknown-none
 
-      - name: Install generic target with no std, no CAS atomics
-        run: rustup target add thumbv6m-arm-eabi
+      - name: Install generic target with no std/atomics
+        run: rustup target add thumbv6m-none-eabi
 
       - name: Install `wasm32-unknown-unknown` target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Run Cargo clippy with no details, no libs
-        run: cargo clippy -- --deny warnings
-
-      - name: Run Cargo clippy with details, no libs
-        run: cargo clippy --features details -- --deny warnings
+      # no-std
 
       - name: Run Cargo clippy with no std, no details, no libs
         run: cargo clippy --target x86_64-unknown-none --no-default-features -- --deny warnings
@@ -63,6 +59,28 @@ jobs:
 
       - name: Run Cargo clippy with no std, details, no-std-compatible libs
         run: cargo clippy --target x86_64-unknown-none --no-default-features --features details,arrayvec,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,url,bitvec -- --deny warnings
+
+      # no-std/atomics
+
+      - name: Run Cargo clippy with no std/atomics, no details, no libs
+        run: cargo clippy --target thumbv6m-none-eabi --no-default-features -- --deny warnings
+
+      - name: Run Cargo clippy with no std/atomics, details, no libs
+        run: cargo clippy --target thumbv6m-none-eabi --no-default-features --features details -- --deny warnings
+
+      - name: Run Cargo clippy with no std/atomics, no details, no-std/atomics-compatible libs
+        run: cargo clippy --target thumbv6m-none-eabi --no-default-features --features arrayvec,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,bitvec -- --deny warnings
+
+      - name: Run Cargo clippy with no std/atomics, details, no-std/atomics-compatible libs
+        run: cargo clippy --target thumbv6m-none-eabi --no-default-features --features details,arrayvec,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,bitvec -- --deny warnings
+
+      # std
+
+      - name: Run Cargo clippy with no details, no libs
+        run: cargo clippy -- --deny warnings
+
+      - name: Run Cargo clippy with details, no libs
+        run: cargo clippy --features details -- --deny warnings
 
       - name: Run Cargo clippy with no details, all libs
         run: cargo clippy --features dashmap,arrayvec,simd_json,halfbrown,parking_lot,serde_json,mini_moka,hashbrown,hashbrown_15,secrecy,chrono,nonmax,time,url,extract_map_01,bitvec,web-time -- --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ time = { version = "0.3.30", default-features = false, optional = true }
 url = { version = "2.4", default-features = false, optional = true }
 extract_map = { version = "0.1.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, features = [
+  "alloc",
+], optional = true }
 nonmax = { version = "0.5.5", default-features = false, optional = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
   "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ time = { version = "0.3.30", default-features = false, optional = true }
 url = { version = "2.4", default-features = false, optional = true }
 extract_map = { version = "0.1.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
-serde_json = { version = "1", optional = true }
-nonmax = { version = "0.5.5", optional = true }
-bitvec = { version = "1.0.1", optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+nonmax = { version = "0.5.5", default-features = false, optional = true }
+bitvec = { version = "1.0.1", default-features = false, features = [
+  "alloc",
+], optional = true }
 web-time = { version = "1.1.0", optional = true }
 typesize-derive = { version = "=0.1.11", path = "typesize-derive" }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -4,8 +4,7 @@ use core::{
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
     },
     sync::atomic::{
-        AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
-        AtomicU64, AtomicU8, AtomicUsize,
+        AtomicBool, AtomicI16, AtomicI8, AtomicIsize, AtomicU16, AtomicU8, AtomicUsize,
     },
 };
 
@@ -29,13 +28,19 @@ sizeof_impl!(
     bool, AtomicBool,
     u8, u16, u32, u64, u128, usize,
     i8, i16, i32, i64, i128, isize,
-    AtomicU8, AtomicU16, AtomicU32, AtomicU64, AtomicUsize,
-    AtomicI8, AtomicI16, AtomicI32, AtomicI64, AtomicIsize,
+    AtomicU8, AtomicU16, AtomicUsize,
+    AtomicI8, AtomicI16, AtomicIsize,
     NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize,
     Wrapping<u8>, Wrapping<u16>, Wrapping<u32>, Wrapping<u64>, Wrapping<u128>, Wrapping<usize>,
     Wrapping<i8>, Wrapping<i16>, Wrapping<i32>, Wrapping<i64>, Wrapping<i128>, Wrapping<isize>
 );
+
+#[cfg(target_has_atomic = "32")]
+sizeof_impl!(core::sync::atomic::AtomicU32, core::sync::atomic::AtomicI32);
+
+#[cfg(target_has_atomic = "64")]
+sizeof_impl!(core::sync::atomic::AtomicU64, core::sync::atomic::AtomicI64);
 
 #[cfg(feature = "saturating_impls")]
 use core::num::Saturating;

--- a/src/ptr/mod.rs
+++ b/src/ptr/mod.rs
@@ -4,9 +4,11 @@ use core::ops::{Deref, DerefMut};
 
 use crate::TypeSize;
 
+#[cfg(target_has_atomic = "ptr")]
 pub use arc::SizableArc;
 pub use rc::SizableRc;
 
+#[cfg(target_has_atomic = "ptr")]
 mod arc;
 mod rc;
 


### PR DESCRIPTION
Targets like `thumbv6m-none-eabi` (which Bevy uses as a reference "no-std/no-64-bit-atomics target") currently fail to compile because typesize assumes `alloc::sync::Arc`, `Atomic(I/U)64` always exist. This PR fixes those by `cfg`ing the impls out, and adds CI to test for this via `--target thumbv6m-none-eabi`.

Some dependencies like `bitvec` are not marked `default-features = false`, meaning if you enable `typesize/std`, then `bitvec/std` is also enabled (even if you don't need it). This PR also fixes these oversights by marking `default-features = false` for dependencies which can be compiled for no-std, and adding CI tests for this as well.

Opinionated: I changed the order of args to `cargo clippy` in CI to make them "broadest-first":
- std/no std
- details/no details
- all libs/no libs

In this PR, a lot of the CI logic is also duplicated, like which features are enabled for which targets. Could this be deduplicated somehow? Feature matrix?

Also, I unconditionally enable `serde_json/alloc` since the crate will not compile without either `std` or `alloc` enabled. I'm not happy with this, but I'm not sure what else to do to allow typesize + serde_json + no_std.