### PR TITLE
fix `#[typesize(with = path::to::fn)]` with `details` enabled

### DIFF
--- a/tests/details.rs
+++ b/tests/details.rs
@@ -4,17 +4,29 @@ use typesize::{derive::TypeSize, Field, TypeSize};
 
 #[test]
 fn test_details() {
+    const UNKNOWN_SIZE: usize = 67;
+
+    #[derive(Default)]
+    struct UnknownTypeSize { }
+
+    fn size_of_unknown(value: &UnknownTypeSize) -> usize {
+        UNKNOWN_SIZE
+    }
+
     #[derive(Default, TypeSize)]
     struct TestDetails {
         likes: Vec<String>,
         name: String,
         age: u8,
+        #[typesize(with = size_of_unknown)]
+        unknown: UnknownTypeSize,
     }
 
     let test = TestDetails {
         likes: vec![String::from("Cats"), String::from("Foxes")],
         name: String::from("Example"),
         age: 18,
+        unknown: UnknownTypeSize::default(),
     };
 
     let test_fields = [
@@ -32,6 +44,11 @@ fn test_details() {
             name: "age",
             collection_items: None,
             size: test.age.get_size(),
+        },
+        Field {
+            name: "unknown",
+            collection_items: None,
+            size: UNKNOWN_SIZE,
         },
     ];
 

--- a/tests/struct_derive.rs
+++ b/tests/struct_derive.rs
@@ -44,18 +44,18 @@ fn struct_skip_attr() {
 fn struct_with_attr() {
     const EXTRA_SIZE: usize = 42;
 
-    fn my_extra_size(_field: &usize) -> usize {
+    fn my_extra_size(_field: &NotTypeSize) -> usize {
         EXTRA_SIZE
     }
 
     #[derive(Default, TypeSize)]
     struct NamedWith {
         #[typesize(with = my_extra_size)]
-        field: usize,
+        field: NotTypeSize,
     }
 
     #[derive(Default, TypeSize)]
-    struct UnnamedWith(#[typesize(with = my_extra_size)] usize);
+    struct UnnamedWith(#[typesize(with = my_extra_size)] NotTypeSize);
 
     assert_eq!(NamedWith::default().extra_size(), EXTRA_SIZE);
     assert_eq!(UnnamedWith::default().extra_size(), EXTRA_SIZE);

--- a/typesize-derive/src/struct.rs
+++ b/typesize-derive/src/struct.rs
@@ -27,12 +27,11 @@ fn field_details_visit_fields<'a>(
                     size_expr = quote!(0);
                     collection_items_expr = quote!(None);
                 }
-                FieldConfig::With(_) => {
-                    size_expr = gen_call_with_arg(
-                        &quote!(::typesize::TypeSize::get_size),
-                        &ident,
-                        arg_pass_mode,
-                    );
+                FieldConfig::With(get_size) => {
+                    use quote::ToTokens;
+
+                    size_expr =
+                        gen_call_with_arg(&get_size.into_token_stream(), &ident, arg_pass_mode);
 
                     collection_items_expr = quote!(None);
                 }


### PR DESCRIPTION
`#[typesize(with = path::to::fn)]` didn't work if `details` feature was enabled and the type of the field did not implement TypeSize.